### PR TITLE
gem install librarian-chef, not librarian

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Clone this repo:
 On your local machine:
 
     cd discourse-chef
-    gem install librarian
+    gem install librarian-chef
     librarian-chef install
 
 ### 2. Bootstrap your server


### PR DESCRIPTION
I noticed a closed Pull Request from a while ago that "corrected"
`gem install librarian` to `gem install librarian-chef`. The gem
is, however, librarian-chef.
